### PR TITLE
Update Client.php To fix output of downloaded file

### DIFF
--- a/lib/ConvertApi/Client.php
+++ b/lib/ConvertApi/Client.php
@@ -63,6 +63,7 @@ class Client
         curl_setopt($ch, CURLOPT_USERAGENT, $this->userAgent());
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, ConvertApi::$connectTimeout);
         curl_setopt($ch, CURLOPT_TIMEOUT, ConvertApi::$downloadTimeout);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 
         $response = curl_exec($ch);
 


### PR DESCRIPTION
Fixes issue where the CURL output is ECHO'd to the request output, its now simply downloaded. When used in a web context, it dumps the file content into the page output, which in our case completely breaks the JSON output!