### PR TITLE
Add getter and setter for $apiBase

### DIFF
--- a/lib/ConvertApi/ConvertApi.php
+++ b/lib/ConvertApi/ConvertApi.php
@@ -58,6 +58,24 @@ class ConvertApi
     }
 
     /**
+     * @return string The API base used for requests.
+     */
+    public static function getApiBase()
+    {
+        return self::$apiBase;
+    }
+
+    /**
+     * Sets API base used for requests.
+     *
+     * @param string $apiBase
+     */
+    public static function setApiBase($apiBase)
+    {
+        self::$apiBase = $apiBase;
+    }
+
+    /**
      * Perform conversion
      *
      * @param string $toFormat Convert to format

--- a/tests/ConvertApi/ConvertApiTest.php
+++ b/tests/ConvertApi/ConvertApiTest.php
@@ -28,6 +28,9 @@ class ConvertApiTest extends \PHPUnit_Framework_TestCase
     {
         ConvertApi::setApiSecret('test-secret');
         $this->assertEquals('test-secret', ConvertApi::getApiSecret());
+
+        ConvertApi::setApiSecret('https://foo.bar');
+        $this->assertEquals('https://foo.bar', ConvertApi::getApiBase());
     }
 
     public function testClient()


### PR DESCRIPTION
See [Add get + set for `$apiBase` to increase testability](https://github.com/ConvertAPI/convertapi-php/issues/27)