### PR TITLE
Fix filename with spaces encoding in file uploads

### DIFF
--- a/lib/ConvertApi/Client.php
+++ b/lib/ConvertApi/Client.php
@@ -28,7 +28,7 @@ class Client
             [
                 'Content-Type: application/octet-stream',
                 'Transfer-Encoding: chunked',
-                "Content-Disposition: attachment; filename*=UTF-8''" . urlencode($fileName),
+                "Content-Disposition: attachment; filename*=UTF-8''" . rawurlencode($fileName),
             ]
         );
 

--- a/tests/ConvertApi/ConvertApiTest.php
+++ b/tests/ConvertApi/ConvertApiTest.php
@@ -96,6 +96,16 @@ class ConvertApiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('custom.pdf', $result->getFile()->getFileName());
     }
 
+    public function testConvertWithFileUploadAndSpaces()
+    {
+        $fileUpload = new \ConvertApi\FileUpload('examples/files/test.docx', 'test space ačiū.docx');
+        $params = ['File' => $fileUpload];
+
+        $result = ConvertApi::convert('pdf', $params);
+
+        $this->assertEquals('test space ačiū.pdf', $result->getFile()->getFileName());
+    }
+
     public function testConvertWithFileResourceUpload()
     {
         $fp = fopen('examples/files/test.docx', 'rb');


### PR DESCRIPTION
Fixes spaces handling: https://github.com/ConvertAPI/convertapi-php/issues/26