### PR TITLE
fix(params): Allow StoreFile param to be overridden

### DIFF
--- a/lib/ConvertApi/Task.php
+++ b/lib/ConvertApi/Task.php
@@ -16,11 +16,11 @@ class Task
 
     function run()
     {
-        $params = array_merge(
-            $this->normalizedParams(),
+        $params = array_replace(
             [
                 'StoreFile' => true,
-            ]
+            ],
+            $this->normalizedParams()
         );
 
         if ($this->conversionTimeout) {

--- a/tests/ConvertApi/ConvertApiTest.php
+++ b/tests/ConvertApi/ConvertApiTest.php
@@ -77,6 +77,15 @@ class ConvertApiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test.pdf', $result->getFile()->getFileName());
     }
 
+    public function testConvertWithStoreFileFalse()
+    {
+        $params = ['File' => 'examples/files/test.docx', 'StoreFile' => false];
+
+        $result = ConvertApi::convert('pdf', $params);
+
+        $this->assertEquals('test.pdf', $result->getFile()->getFileName());
+    }
+
     public function testConvertWithAltnativeConverter()
     {
         $params = ['File' => 'examples/files/test.docx', 'converter' => 'openoffice'];


### PR DESCRIPTION
I would like to set `StoreFile` to be `false` when converting a file. 

This change allows the default `StoreFile` parameter to be overridden by the given parameters.