### PR TITLE
Do not set content type header when uploading file

### DIFF
--- a/lib/ConvertApi/Client.php
+++ b/lib/ConvertApi/Client.php
@@ -26,8 +26,6 @@ class Client
         $headers = array_merge(
             $this->defaultHeaders(),
             [
-                'Content-Type: application/octet-stream',
-                'Transfer-Encoding: chunked',
                 "Content-Disposition: attachment; filename*=UTF-8''" . rawurlencode($fileName),
             ]
         );

--- a/tests/ConvertApi/ConvertApiTest.php
+++ b/tests/ConvertApi/ConvertApiTest.php
@@ -48,6 +48,37 @@ class ConvertApiTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('SecondsLeft', $user_info);
     }
 
+    public function testUploadFile()
+    {
+        $file = 'examples/files/test.docx';
+
+        $fileContents = file_get_contents($file);
+        $crc = hash('crc32b', $fileContents);
+
+        $result = ConvertApi::client()->upload($file, 'test.docx');
+        $uploadedContents = file_get_contents($result['Url']);
+        $uploadedCrc = hash('crc32b', $uploadedContents);
+
+        $this->assertEquals($crc, $uploadedCrc);
+    }
+
+    public function testUploadStream()
+    {
+        $file = 'examples/files/test.docx';
+        $fileContents = file_get_contents($file);
+        $crc = hash('crc32b', $fileContents);
+
+        $stream = fopen('php://memory', 'rwb');
+        fwrite($stream, $fileContents);
+        rewind($stream);
+
+        $result = ConvertApi::client()->upload($stream, 'test.docx');
+        $uploadedContents = file_get_contents($result['Url']);
+        $uploadedCrc = hash('crc32b', $uploadedContents);
+
+        $this->assertEquals($crc, $uploadedCrc);
+    }
+
     public function testConvertWithFileUrl()
     {
         $params = ['File' => 'https://cdn.convertapi.com/cara/testfiles/document.docx?test=1'];


### PR DESCRIPTION
Removing headers fixes upload issues for some users:
https://github.com/ConvertAPI/convertapi-php/issues/56

