### PR TITLE
Fix phpdoc for ResultFile's getContents function

### DIFF
--- a/lib/ConvertApi/ResultFile.php
+++ b/lib/ConvertApi/ResultFile.php
@@ -36,7 +36,7 @@ class ResultFile
     }
 
     /**
-     * @return string Converted file contents
+     * @return false|string Converted file contents
      */
     function getContents()
     {


### PR DESCRIPTION
## Overview
The `getContents` method of the `ResultFile` class has a return type specified as string, but the return type of the internally used `file_get_contents` can be `false|string`, which means that the `getContents` method's return type is incorrectly annotated. In fact, there have been instances in the service I am developing where it returned false.

Therefore, I have updated the PHPDoc to match the return type of `file_get_contents`.